### PR TITLE
SD-1216 Prevent applying CDN domain on selected non-src attributes

### DIFF
--- a/src/Components/ImageTransformer.php
+++ b/src/Components/ImageTransformer.php
@@ -82,7 +82,9 @@ class ImageTransformer implements ImageTransformerInterface
         // apply the cdn domain on the remaining attributes
         foreach ($image->attributes as $attribute) {
             if (!in_array($attribute->name, $processedAttributes)) {
-                $this->applyCdnDomain($attribute);
+                if (!in_array($attribute->name, ['alt', 'title', 'class'])) {
+                    $this->applyCdnDomain($attribute);
+                }
             }
         }
 
@@ -107,11 +109,6 @@ class ImageTransformer implements ImageTransformerInterface
      */
     private function applyCdnDomain(\DOMAttr $attribute)
     {
-        // prevent 'unterminated entity reference' error when & and &amp are present in text
-        if (false !== \strstr($attribute->value, '& ') || false !== \strstr($attribute->value, '&amp; ')) {
-            return;
-        }
-
         $words = preg_split("/[\s]+/", $attribute->value);
         $processedWords = [];
 


### PR DESCRIPTION
Prevent applying CDN domain on attributes that might contain special characters (e.g. & oder &amp;)